### PR TITLE
feat: Add lazy loading to images in markdown content

### DIFF
--- a/lib/markdownToHtml.ts
+++ b/lib/markdownToHtml.ts
@@ -3,5 +3,12 @@ import html from 'remark-html'
 
 export default async function markdownToHtml(markdown: string) {
   const result = await remark().use(html).process(markdown)
-  return result.toString()
+  let processedHtml = result.toString();
+  processedHtml = processedHtml.replace(/<img([^>]+)>/g, (match, p1) => {
+    if (p1.includes('loading=')) {
+      return match;
+    }
+    return `<img${p1} loading="lazy">`;
+  });
+  return processedHtml;
 }


### PR DESCRIPTION
This PR introduces lazy loading for images rendered from markdown content, improving performance by deferring the loading of off-screen images.