### PR TITLE
fix: replace tab character with space in date format string

### DIFF
--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from "react";
+
 type Props = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
 };
 

--- a/components/date-formatter.tsx
+++ b/components/date-formatter.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 const DateFormatter = ({ dateString }: Props) => {
   const date = parseISO(dateString)
-  return <time dateTime={dateString}>{format(date, 'LLLL	d, yyyy')}</time>
+  return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>
 }
 
 export default DateFormatter


### PR DESCRIPTION
## Problem

The `DateFormatter` component had a literal tab character inside the `date-fns` format string instead of a regular space:

```ts
// Before — note the tab between LLLL and d
format(date, 'LLLL\td, yyyy')

// After
format(date, 'LLLL d, yyyy')
```

This caused all blog post dates to render with a visible tab between the month and day number.

## Changes

- `components/date-formatter.tsx` — Replace tab character with a space in the format string
- `components/container.tsx` — Add explicit `import type { ReactNode } from "react"` to replace the unresolved global `React.ReactNode` reference (TypeScript best practice)