### PR TITLE
seo: add BlogPosting JSON-LD structured data to post pages

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import ErrorPage from "next/error";
 import { useRouter } from "next/router";
 
@@ -9,7 +10,7 @@ import PostHeader from "../../components/post-header";
 import PostTitle from "../../components/post-title";
 import type PostType from "../../interfaces/post";
 import { getPostBySlug, getAllPosts } from "../../lib/api";
-import { SITE_NAME, SITE_URL } from "../../lib/constants";
+import { SITE_NAME, SITE_URL, AUTHOR_NAME, HOME_OG_IMAGE_URL } from "../../lib/constants";
 import markdownToHtml from "../../lib/markdownToHtml";
 
 type Props = {
@@ -23,6 +24,35 @@ export default function Post({ post, morePosts: _morePosts, preview }: Props) {
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />;
   }
+
+  const canonicalUrl = `${SITE_URL}/posts/${post.slug}`;
+  const structuredData = !router.isFallback
+    ? {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        headline: post.title,
+        description: post.excerpt || `${post.title} by ${SITE_NAME}`,
+        image: post.ogImage?.url || HOME_OG_IMAGE_URL,
+        datePublished: post.date,
+        dateModified: post.date,
+        author: {
+          "@type": "Person",
+          name: post.author?.name || AUTHOR_NAME,
+          url: SITE_URL,
+        },
+        publisher: {
+          "@type": "Person",
+          name: AUTHOR_NAME,
+          url: SITE_URL,
+        },
+        url: canonicalUrl,
+        mainEntityOfPage: {
+          "@type": "WebPage",
+          "@id": canonicalUrl,
+        },
+      }
+    : null;
+
   return (
     <Layout
       preview={preview}
@@ -30,9 +60,17 @@ export default function Post({ post, morePosts: _morePosts, preview }: Props) {
         title: post.title,
         description: post.excerpt || `${post.title} by ${SITE_NAME}`,
         ogImage: post.ogImage?.url,
-        canonicalUrl: `${SITE_URL}/posts/${post.slug}`,
+        canonicalUrl,
       }}
     >
+      {structuredData && (
+        <Head>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+          />
+        </Head>
+      )}
       <Container className="max-w-5xl">
         <Header />
         {router.isFallback ? (


### PR DESCRIPTION
## Summary

Individual blog post pages at `/posts/[slug]` were missing article-level structured data. The site's `_document.tsx` already injects a `Person` schema for the homepage, but Google also uses **BlogPosting** schema on article pages for rich results (article cards, author info, date in search snippets).

## Changes

- **`pages/posts/[slug].tsx`**: Added `BlogPosting` JSON-LD structured data injected via `<Head>`
  - `headline`, `description`, `image`, `datePublished`, `dateModified`
  - `author` and `publisher` (Person type, links back to site root)
  - `url` + `mainEntityOfPage` for canonical linking
  - Guarded with `!router.isFallback` so it only renders when post data is available
  - Reuses existing constants (`AUTHOR_NAME`, `HOME_OG_IMAGE_URL`) for consistency

## Why

Schema.org's [BlogPosting](https://schema.org/BlogPosting) type enables Google to display richer search results for individual posts — article structured snippets, publication date, and author attribution. This is a low-risk, high-value SEO improvement with no runtime cost.